### PR TITLE
[FEAT] Input 컴포넌트, 스토리북

### DIFF
--- a/src/assets/icons/delete-round.svg
+++ b/src/assets/icons/delete-round.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="16" height="16" rx="8" fill="#7F8996"/>
+<path d="M10.5 5.5L5.5 10.5M10.5 10.5L5.5 5.5" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icons/index.tsx
+++ b/src/assets/icons/index.tsx
@@ -2,6 +2,7 @@ import Bar from './bar.svg?react';
 import EmptyBookMark from './bookmark-empty.svg?react';
 import BookMark from './bookmark.svg?react';
 import Cafe from './cafe-dessert.svg?react';
+import DeleteRound from './delete-round.svg?react';
 import Findy1 from './findy-1.svg?react';
 import Findy2 from './findy-2.svg?react';
 import Findy3 from './findy-3.svg?react';
@@ -40,6 +41,7 @@ export const Icons = {
   map: Map,
   location: Location,
   marker: Marker,
+  deleteRound: DeleteRound,
   kakaoLogin: KakaoLogin,
   naverLogin: NaverLogin,
   findy1: Findy1,

--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -4,7 +4,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useInput } from '@/hooks/common/useInput';
 
 import { Input } from '.';
-import { Layout } from '../Layout';
 
 const meta = {
   title: 'components/common/Input',
@@ -19,7 +18,7 @@ export const Basic: Story = {
   render: () => {
     const { state, onChange, onClickReset, isValid, onBlur, ref } = useInput();
     return (
-      <Layout>
+      <div className=" w-96">
         <Input
           value={state}
           onChange={onChange}
@@ -28,7 +27,7 @@ export const Basic: Story = {
           isValid={isValid}
           ref={ref}
         />
-      </Layout>
+      </div>
     );
   },
 };

--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -18,7 +18,7 @@ export const Basic: Story = {
   render: () => {
     const { state, onChange, onClickReset, isValid, onBlur, ref } = useInput();
     return (
-      <div className=" w-96">
+      <div className=" max-w-96 w-full">
         <Input
           value={state}
           onChange={onChange}

--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable no-restricted-exports */
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useInput } from '@/hooks/common/useInput';
+
+import { Input } from '.';
+import { Layout } from '../Layout';
+
+const meta = {
+  title: 'components/common/Input',
+  component: Input,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Basic: Story = {
+  render: () => {
+    const { state, onChange, onClickReset, isValid, onBlur, ref } = useInput();
+    return (
+      <Layout>
+        <Input
+          value={state}
+          onChange={onChange}
+          onBlur={onBlur}
+          onClickReset={onClickReset}
+          isValid={isValid}
+          ref={ref}
+        />
+      </Layout>
+    );
+  },
+};

--- a/src/components/common/Input/Input.types.ts
+++ b/src/components/common/Input/Input.types.ts
@@ -13,4 +13,8 @@ export type Props = {
    * Indicates whether the current input value is valid.
    */
   isValid: boolean;
+  /*
+   * Optional error message to display when validation fails.
+   */
+  errorMessage?: string;
 } & ComponentPropsWithoutRef<'input'>;

--- a/src/components/common/Input/Input.types.ts
+++ b/src/components/common/Input/Input.types.ts
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, ComponentPropsWithoutRef } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
 export type Props = {
   /*
@@ -6,15 +6,11 @@ export type Props = {
    */
   value: string;
   /*
-   * The current value of the input field.
-   */
-  onChange: ChangeEventHandler<HTMLInputElement>;
-  /*
-   * The current value of the input field.
+   * Function to reset the input value to its initial state.
    */
   onClickReset: VoidFunction;
   /*
-   * indicating whether the input value is valid or not.
+   * Indicates whether the current input value is valid.
    */
   isValid: boolean;
 } & ComponentPropsWithoutRef<'input'>;

--- a/src/components/common/Input/Input.types.ts
+++ b/src/components/common/Input/Input.types.ts
@@ -1,0 +1,20 @@
+import { ChangeEventHandler, ComponentPropsWithoutRef } from 'react';
+
+export type Props = {
+  /*
+   * The current value of the input field.
+   */
+  value: string;
+  /*
+   * The current value of the input field.
+   */
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  /*
+   * The current value of the input field.
+   */
+  onClickReset: VoidFunction;
+  /*
+   * indicating whether the input value is valid or not.
+   */
+  isValid: boolean;
+} & ComponentPropsWithoutRef<'input'>;

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -1,0 +1,39 @@
+import { forwardRef } from 'react';
+
+import { Props } from './Input.types';
+
+import { Icon } from '../Icon';
+import { Caption } from '../Typography';
+
+export const Input = forwardRef<HTMLInputElement, Props>(
+  ({ value, onChange, onClickReset, isValid, onBlur, ...props }, ref) => {
+    const helperMessage = !isValid && value.length > 0;
+
+    return (
+      <div className="flex flex-col items-start w-full">
+        <div className="relative flex items-center w-full">
+          <input
+            value={value}
+            onChange={onChange}
+            onBlur={onBlur}
+            ref={ref}
+            placeholder="링크를 입력해주세요."
+            className="w-full h-11 text-body3 bg-gray-50 pl-5 pr-10 rounded-lg outline-none focus:outline-1 focus:outline-offset-0 focus:outline-gray-500 transition-colors"
+            {...props}
+          />
+          {value && (
+            <div
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer"
+              onClick={onClickReset}
+            >
+              <Icon name="deleteRound" size={16} />
+            </div>
+          )}
+        </div>
+        {helperMessage && (
+          <Caption className="text-primary mt-1">유투브 링크 혹은 지도 링크만 가능합니다.</Caption>
+        )}
+      </div>
+    );
+  }
+);

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -6,7 +6,18 @@ import { Icon } from '../Icon';
 import { Caption } from '../Typography';
 
 export const Input = forwardRef<HTMLInputElement, Props>(
-  ({ value, onChange, onClickReset, isValid, onBlur, ...props }, ref) => {
+  (
+    {
+      value = '',
+      onChange,
+      onClickReset = () => {},
+      isValid = true,
+      onBlur = () => {},
+      errorMessage = '',
+      ...props
+    },
+    ref
+  ) => {
     const helperMessage = !isValid && value.length > 0;
 
     return (
@@ -31,7 +42,9 @@ export const Input = forwardRef<HTMLInputElement, Props>(
           )}
         </div>
         {helperMessage && (
-          <Caption className="text-primary mt-1">유투브 링크 혹은 지도 링크만 가능합니다.</Caption>
+          <Caption className="text-primary mt-1">
+            {errorMessage || '유투브 링크 혹은 지도 링크만 가능합니다.'}
+          </Caption>
         )}
       </div>
     );

--- a/src/hooks/common/useInput.tsx
+++ b/src/hooks/common/useInput.tsx
@@ -1,6 +1,6 @@
 import { ChangeEventHandler, useCallback, useRef, useState } from 'react';
 
-export const useInput = (initialValue = '') => {
+export const useInput = (initialValue = '', validation: string[] = ['youtube', 'www']) => {
   const [state, setState] = useState(initialValue);
   const [isValid, setIsValid] = useState(true);
   const ref = useRef<HTMLInputElement>(null);
@@ -12,9 +12,9 @@ export const useInput = (initialValue = '') => {
 
   const onBlur = useCallback(() => {
     if (state.length > 0) {
-      setIsValid(state.includes('youtube') || state.includes('www.'));
+      setIsValid(validation.some((criteria) => state.includes(criteria)));
     }
-  }, [state]);
+  }, [state, validation]);
 
   const onClickReset = useCallback(() => {
     setState(initialValue);

--- a/src/hooks/common/useInput.tsx
+++ b/src/hooks/common/useInput.tsx
@@ -1,0 +1,28 @@
+import { ChangeEventHandler, useCallback, useRef, useState } from 'react';
+
+export const useInput = (initialValue = '') => {
+  const [state, setState] = useState(initialValue);
+  const [isValid, setIsValid] = useState(true);
+  const ref = useRef<HTMLInputElement>(null);
+
+  const onChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
+    const value = e.target.value;
+    setState(value);
+  }, []);
+
+  const onBlur = useCallback(() => {
+    if (state.length > 0) {
+      setIsValid(state.includes('youtube') || state.includes('www.'));
+    }
+  }, [state]);
+
+  const onClickReset = useCallback(() => {
+    setState(initialValue);
+    setIsValid(true);
+    if (ref.current) {
+      ref.current.focus();
+    }
+  }, [initialValue]);
+
+  return { state, onChange, onBlur, onClickReset, isValid, ref };
+};


### PR DESCRIPTION
<!-- PR 제목입니다. -->

## 관련 이슈

close #14 

## 📑 작업 내용

- Input 컴포넌트, 스토리북 구현했습니다.
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 💬 리뷰 중점 사항/기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 새로운 `DeleteRound` 아이콘 추가.
  - `Input` 컴포넌트와 관련된 새로운 스토리 추가.
  - 사용자 입력을 관리하는 `useInput` 커스텀 훅 추가.
  - 입력 필드에 대한 새로운 `Input` 컴포넌트 추가.

- **타입 정의**
  - 입력 컴포넌트의 속성을 정의하는 `Props` 타입 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->