### PR TITLE
[FEAT] SideMenu 연결

### DIFF
--- a/src/components/common/IconButton/index.tsx
+++ b/src/components/common/IconButton/index.tsx
@@ -8,7 +8,7 @@ export const IconButton = ({ name, isActive, className, ...props }: Props) => {
   return (
     <button
       className={cn(
-        'p-3 rounded-full transition-colors border shadow-md shadow-gray-300 ',
+        'p-3 rounded-full transition-colors border shadow-md shadow-gray-300 bg-white',
         name === 'bookMark'
           ? isActive
             ? 'border-primary'

--- a/src/components/common/SideMenu/SideMenu.stories.tsx
+++ b/src/components/common/SideMenu/SideMenu.stories.tsx
@@ -21,7 +21,7 @@ export const Basic: Story = {
     position: 'left',
   },
   argTypes: {
-    variant: { control: { type: 'radio' }, options: ['gps', 'link', 'bookMark'] },
+    variant: { control: { type: 'radio' }, options: ['gps', 'link', 'emptyBookMark'] },
     position: { control: { type: 'radio' }, options: ['left', 'right'] },
   },
   render: (args) => {

--- a/src/components/common/SideMenu/index.tsx
+++ b/src/components/common/SideMenu/index.tsx
@@ -23,7 +23,7 @@ const SideMenuGroup = ({ position = 'left', children, ...props }: GroupProps) =>
   return (
     <div
       className={cn(
-        `w-fit wrap flex flex-col gap-4 ${position === 'left' ? 'left-4' : 'right-4'}         `
+        `w-fit wrap flex flex-col gap-3 ${position === 'left' ? 'left-4' : 'right-4'}         `
       )}
       {...props}
     >

--- a/src/constants/sideMenuItem.ts
+++ b/src/constants/sideMenuItem.ts
@@ -1,7 +1,7 @@
-export const sideMenuItem = ['gps', 'bookMark', 'link'] as const;
+export const sideMenuItem = ['gps', 'emptyBookMark', 'link'] as const;
 
 export const sideMenuTooltip = {
   gps: '현재 위치로',
-  bookMark: '즐겨찾기',
+  emptyBookMark: '즐겨찾기',
   link: '링크 입력하기',
 } as const;

--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer base {
-  html {
-    font-family: 'Pretendard';
-  }
+@font-face {
+  font-style: normal;
+  font-display: swap;
+  font-family: 'Pretendard';
+  src: url('/fonts/PretendardVariable.woff2') format('woff2-variations');
 }

--- a/src/pages/MapView.tsx
+++ b/src/pages/MapView.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { SearchInput } from '@/components/common/SearchInput';
+import { SideMenu } from '@/components/common/SideMenu';
 import { NaverMap } from '@/components/features/NaverMap';
 
 export const MapView = () => {
+  const navigate = useNavigate();
   const [searchValue, setSearchValue] = useState('');
 
   const handleChange = (value: string) => {
@@ -22,6 +25,13 @@ export const MapView = () => {
           />
         </div>
         <NaverMap />
+        <div className="absolute bottom-14 right-4 flex flex-col gap-2 justify-center items-center">
+          <SideMenu.Group>
+            <SideMenu position="right" variant="gps" onClick={() => {}} />
+            <SideMenu position="right" variant="link" onClick={() => navigate('/link')} />
+            <SideMenu position="right" variant="emptyBookMark" onClick={() => {}} />
+          </SideMenu.Group>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
<!-- PR 제목입니다. -->

## 관련 이슈

close #37 

## 📑 작업 내용

- SideMenu 연결하고 Link 페이지 연결 작업했습니다.

https://github.com/user-attachments/assets/513d8ae7-6da4-4dfe-92bb-f54219a81cf6


<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 💬 리뷰 중점 사항/기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 지도 보기에서 사용자에게 추가 내비게이션 옵션을 제공하는 `SideMenu` 컴포넌트를 추가했습니다.
	- `SideMenu` 아이템 중 하나를 클릭하면 `/link` 경로로 이동할 수 있습니다.
- **변경 사항**
	- `IconButton`의 배경 색상을 흰색으로 변경했습니다.
	- `SideMenu`의 `variant` 옵션을 업데이트하여 `emptyBookMark`를 추가했습니다.
	- `SideMenuGroup`의 요소 간 간격을 조정하여 더 컴팩트한 레이아웃을 구현했습니다.
	- 즐겨찾기 항목의 이름을 `emptyBookMark`로 변경했습니다.
	- 애플리케이션 전반에 걸쳐 'Pretendard' 폰트를 적용하도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->