### PR TITLE
[FEAT] ListCard 컴포넌트, 스토리북 구현

### DIFF
--- a/src/components/common/ListCard/ListCard.stories.tsx
+++ b/src/components/common/ListCard/ListCard.stories.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable no-restricted-exports */
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ListCard } from '.';
+import { Body1 } from '../Typography';
+
+const meta = {
+  title: 'components/common/ListCard',
+  component: ListCard,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ListCard>;
+
+export default meta;
+type Story = StoryObj<typeof ListCard>;
+
+export const Basic: Story = {
+  render: () => {
+    return (
+      <>
+        <ListCard>
+          <Body1>핀디, 순간을 PIN에 담아보세요!</Body1>
+        </ListCard>
+      </>
+    );
+  },
+};

--- a/src/components/common/ListCard/ListCard.types.ts
+++ b/src/components/common/ListCard/ListCard.types.ts
@@ -1,0 +1,8 @@
+import { ComponentPropsWithoutRef } from 'react';
+
+export type Props = {
+  /**
+   * The children of the card
+   */
+  children: React.ReactNode;
+} & ComponentPropsWithoutRef<'div'>;

--- a/src/components/common/ListCard/index.tsx
+++ b/src/components/common/ListCard/index.tsx
@@ -1,0 +1,11 @@
+import { forwardRef } from 'react';
+
+import { Props } from './ListCard.types';
+
+export const ListCard = forwardRef<HTMLDivElement, Props>(({ children, ...props }, ref) => {
+  return (
+    <div className="w-full h-fit py-6 pl-6 pr-3.5 rounded-2xl bg-gray-100" {...props} ref={ref}>
+      {children}
+    </div>
+  );
+});


### PR DESCRIPTION
<!-- PR 제목입니다. -->

## 관련 이슈

close #31 

## 📑 작업 내용

- ListCard 컴포넌트, 스토리북 구현했습니다.

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 💬 리뷰 중점 사항/기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - `ListCard` 컴포넌트 추가: 다양한 콘텐츠를 수용할 수 있는 유연한 카드 컴포넌트.
  - Storybook에 `ListCard`의 기본 스토리 추가: 컴포넌트를 시각화하고 테스트할 수 있는 환경 제공.
  
- **타입 정의**
  - `Props` 타입 정의 추가: 표준 HTML `div` 속성을 확장하고, `children` 속성을 통해 React 노드를 수용할 수 있도록 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->