### PR TITLE
[FEAT] 현재 위치로 이동

### DIFF
--- a/src/components/features/NaverMap/NaverMap.types.ts
+++ b/src/components/features/NaverMap/NaverMap.types.ts
@@ -27,6 +27,11 @@ export type Props = {
    */
   initialZoom?: number;
   /**
+   * Determines whether the map centers on the user's current position.
+   * @default false
+   */
+  isCurrent?: boolean;
+  /**
    * Optional React nodes to be rendered as children within the map container.
    */
   children?: React.ReactNode;

--- a/src/components/features/NaverMap/index.tsx
+++ b/src/components/features/NaverMap/index.tsx
@@ -3,17 +3,24 @@ import { memo, useCallback, useEffect, useRef } from 'react';
 import { useMarkers } from '@/hooks/common/useMarkers';
 import { addMarkersToMap } from '@/utils/naver/addMarkersToMap';
 import { clearExistingMarkers } from '@/utils/naver/clearExistingMarkers';
+import { currentMarkersToMap } from '@/utils/naver/currentMakersToMap';
 import { updateMarkerTitles } from '@/utils/naver/updateMarkerTitles';
 
 import { Props } from './NaverMap.types';
 
 // TODO : 대한민국 내에서만 표시 가능하도록 validation 추가
 export const NaverMap = memo(
-  ({ initialCenter = { lat: 37.549681, lng: 126.991911 }, initialZoom = 13 }: Props) => {
+  ({
+    initialCenter = { lat: 37.549681, lng: 126.991911 },
+    initialZoom = 13,
+    isCurrent = false,
+  }: Props) => {
     const mapRef = useRef<HTMLDivElement>(null);
     const mapInstance = useRef<naver.maps.Map | null>(null);
     const markersRef = useRef<naver.maps.Marker[]>([]);
     const markerDataRef = useRef<Array<{ title: string; category: string }>>([]);
+    const currentLocationMarkerRef = useRef<naver.maps.Marker | null>(null);
+
     const { markers } = useMarkers();
 
     const handleZoomChange = useCallback((zoomLevel: number) => {
@@ -22,10 +29,14 @@ export const NaverMap = memo(
 
     const clearMarkers = useCallback(() => {
       clearExistingMarkers(markersRef, markerDataRef);
+      if (currentLocationMarkerRef.current) {
+        currentLocationMarkerRef.current.setMap(null);
+        currentLocationMarkerRef.current = null;
+      }
     }, []);
 
     useEffect(() => {
-      if (mapRef.current && window.naver) {
+      if (mapRef.current && window.naver && !mapInstance.current) {
         const center = new window.naver.maps.LatLng(initialCenter.lat, initialCenter.lng);
         const map = new window.naver.maps.Map(mapRef.current, {
           center,
@@ -43,14 +54,17 @@ export const NaverMap = memo(
           mapInstance.current = null;
         };
       }
-    }, [initialCenter.lat, initialCenter.lng, initialZoom, handleZoomChange]);
+    }, [initialZoom, handleZoomChange, initialCenter.lat, initialCenter.lng]);
 
     useEffect(() => {
       if (mapInstance.current && markers.length > 0) {
         return addMarkersToMap(mapInstance, markers, markersRef, markerDataRef, clearMarkers);
       }
+      if (mapInstance.current && isCurrent) {
+        return currentMarkersToMap(initialCenter, mapInstance.current, currentLocationMarkerRef);
+      }
       clearMarkers();
-    }, [clearMarkers, markers]);
+    }, [clearMarkers, initialCenter, isCurrent, markers]);
 
     return <div id="map" ref={mapRef} style={{ width: '100%', height: '100vh' }} />;
   }

--- a/src/components/features/NaverMap/index.tsx
+++ b/src/components/features/NaverMap/index.tsx
@@ -3,7 +3,7 @@ import { memo, useCallback, useEffect, useRef } from 'react';
 import { useMarkers } from '@/hooks/common/useMarkers';
 import { addMarkersToMap } from '@/utils/naver/addMarkersToMap';
 import { clearExistingMarkers } from '@/utils/naver/clearExistingMarkers';
-import { currentMarkersToMap } from '@/utils/naver/currentMakersToMap';
+import { currentMarkersToMap } from '@/utils/naver/currentMarkersToMap';
 import { updateMarkerTitles } from '@/utils/naver/updateMarkerTitles';
 
 import { Props } from './NaverMap.types';
@@ -41,6 +41,7 @@ export const NaverMap = memo(
         const map = new window.naver.maps.Map(mapRef.current, {
           center,
           zoom: initialZoom,
+          draggable: true,
         });
 
         const listener = window.naver.maps.Event.addListener(map, 'zoom_changed', () => {
@@ -58,12 +59,12 @@ export const NaverMap = memo(
 
     useEffect(() => {
       if (mapInstance.current && markers.length > 0) {
-        return addMarkersToMap(mapInstance, markers, markersRef, markerDataRef, clearMarkers);
+        addMarkersToMap(mapInstance, markers, markersRef, markerDataRef, clearMarkers);
       }
       if (mapInstance.current && isCurrent) {
-        return currentMarkersToMap(initialCenter, mapInstance.current, currentLocationMarkerRef);
+        currentMarkersToMap(initialCenter, mapInstance.current, currentLocationMarkerRef);
       }
-      clearMarkers();
+      return () => clearMarkers();
     }, [clearMarkers, initialCenter, isCurrent, markers]);
 
     return <div id="map" ref={mapRef} style={{ width: '100%', height: '100vh' }} />;

--- a/src/components/features/NaverMap/index.tsx
+++ b/src/components/features/NaverMap/index.tsx
@@ -1,9 +1,9 @@
 import { memo, useCallback, useEffect, useRef } from 'react';
 
 import { useMarkers } from '@/hooks/common/useMarkers';
-import { addMarkersToMap } from '@/utils/naver/addMarkersToMap';
+import { addMarkerToMap } from '@/utils/naver/addMarkerToMap';
 import { clearExistingMarkers } from '@/utils/naver/clearExistingMarkers';
-import { currentMarkersToMap } from '@/utils/naver/currentMarkersToMap';
+import { currentMarkerToMap } from '@/utils/naver/currentMarkerToMap';
 import { updateMarkerTitles } from '@/utils/naver/updateMarkerTitles';
 
 import { Props } from './NaverMap.types';
@@ -59,10 +59,10 @@ export const NaverMap = memo(
 
     useEffect(() => {
       if (mapInstance.current && markers.length > 0) {
-        addMarkersToMap(mapInstance, markers, markersRef, markerDataRef, clearMarkers);
+        addMarkerToMap(mapInstance, markers, markersRef, markerDataRef, clearMarkers);
       }
       if (mapInstance.current && isCurrent) {
-        currentMarkersToMap(initialCenter, mapInstance.current, currentLocationMarkerRef);
+        currentMarkerToMap(initialCenter, mapInstance.current, currentLocationMarkerRef);
       }
       return () => clearMarkers();
     }, [clearMarkers, initialCenter, isCurrent, markers]);

--- a/src/hooks/common/useMapState.tsx
+++ b/src/hooks/common/useMapState.tsx
@@ -1,9 +1,14 @@
 import { useState, useCallback } from 'react';
 
+import { Coordinates } from '@/components/features/NaverMap/NaverMap.types';
+
 export const useMapState = (initialLat = 37.549681, initialLng = 126.991911, initialZoom = 13) => {
-  const [initialCenter, setInitialCenter] = useState({ lat: initialLat, lng: initialLng });
-  const [zoomLevel, setZoomLevel] = useState(initialZoom);
-  const [isCurrent, setIsCurrent] = useState(false);
+  const [initialCenter, setInitialCenter] = useState<Coordinates>({
+    lat: initialLat,
+    lng: initialLng,
+  });
+  const [zoomLevel, setZoomLevel] = useState<number>(initialZoom);
+  const [isCurrent, setIsCurrent] = useState<boolean>(false);
 
   const updateLocation = useCallback((lat: number, lng: number, zoom: number) => {
     setInitialCenter({ lat, lng });

--- a/src/hooks/common/useMapState.tsx
+++ b/src/hooks/common/useMapState.tsx
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react';
+
+export const useMapState = (initialLat = 37.549681, initialLng = 126.991911, initialZoom = 13) => {
+  const [initialCenter, setInitialCenter] = useState({ lat: initialLat, lng: initialLng });
+  const [zoomLevel, setZoomLevel] = useState(initialZoom);
+  const [isCurrent, setIsCurrent] = useState(false);
+
+  const updateLocation = useCallback((lat: number, lng: number, zoom: number) => {
+    setInitialCenter({ lat, lng });
+    setZoomLevel(zoom);
+    setIsCurrent(true);
+  }, []);
+
+  const resetCurrentLocation = useCallback(() => {
+    setIsCurrent(false);
+  }, []);
+
+  return {
+    initialCenter,
+    zoomLevel,
+    isCurrent,
+    updateLocation,
+    resetCurrentLocation,
+  };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,18 @@
   font-family: 'Pretendard';
   src: url('/fonts/PretendardVariable.woff2') format('woff2-variations');
 }
+
+@keyframes ping {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  75% {
+    transform: scale(2);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}

--- a/src/pages/MapView.tsx
+++ b/src/pages/MapView.tsx
@@ -12,11 +12,13 @@ import { Place } from '@/types/naver';
 
 export const MapView = () => {
   const navigate = useNavigate();
+  const [isInputDisabled, setIsInputDisabled] = useState(false);
+
   const { addMarker, clearMarkers } = useMarkers();
   const { state: searchValue, onChange, onClickReset } = useInput();
+  const { refetch } = useNaverSearchResult(searchValue);
   const { initialCenter, zoomLevel, isCurrent, updateLocation, resetCurrentLocation } =
     useMapState();
-  const [isInputDisabled, setIsInputDisabled] = useState(false);
 
   const location = useLocation();
   const data = location.state?.data;
@@ -34,8 +36,6 @@ export const MapView = () => {
       });
     }
   }, [addMarker, clearMarkers, data]);
-
-  const { refetch } = useNaverSearchResult(searchValue);
 
   const handleSearch = async () => {
     setIsInputDisabled(true);
@@ -66,6 +66,11 @@ export const MapView = () => {
     });
   }, [clearMarkers, updateLocation]);
 
+  const handleLink = () => {
+    clearMarkers();
+    navigate('/link');
+  };
+
   return (
     <>
       <div className="relative">
@@ -81,7 +86,7 @@ export const MapView = () => {
         <div className="absolute bottom-10 right-4 flex flex-col gap-2 justify-center items-center">
           <SideMenu.Group>
             <SideMenu position="right" variant="gps" onClick={() => handleCurrentLocation()} />
-            <SideMenu position="right" variant="link" onClick={() => navigate('/link')} />
+            <SideMenu position="right" variant="link" onClick={() => handleLink()} />
             <SideMenu position="right" variant="emptyBookMark" onClick={() => {}} />
           </SideMenu.Group>
         </div>

--- a/src/pages/MapView.tsx
+++ b/src/pages/MapView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { SearchInput } from '@/components/common/SearchInput';
@@ -6,6 +6,7 @@ import { SideMenu } from '@/components/common/SideMenu';
 import { NaverMap } from '@/components/features/NaverMap';
 import { useNaverSearchResult } from '@/hooks/api/search/useNaverSearchResult';
 import { useInput } from '@/hooks/common/useInput';
+import { useMapState } from '@/hooks/common/useMapState';
 import { useMarkers } from '@/hooks/common/useMarkers';
 import { Place } from '@/types/naver';
 
@@ -13,6 +14,8 @@ export const MapView = () => {
   const navigate = useNavigate();
   const { addMarker, clearMarkers } = useMarkers();
   const { state: searchValue, onChange, onClickReset } = useInput();
+  const { initialCenter, zoomLevel, isCurrent, updateLocation, resetCurrentLocation } =
+    useMapState();
   const [isInputDisabled, setIsInputDisabled] = useState(false);
 
   const location = useLocation();
@@ -36,6 +39,7 @@ export const MapView = () => {
 
   const handleSearch = async () => {
     setIsInputDisabled(true);
+    resetCurrentLocation();
     const result = await refetch();
     const newData = result?.data?.data.items;
 
@@ -54,6 +58,14 @@ export const MapView = () => {
     setIsInputDisabled(false);
   };
 
+  const handleCurrentLocation = useCallback(() => {
+    clearMarkers();
+    navigator.geolocation.getCurrentPosition((position) => {
+      const { latitude, longitude } = position.coords;
+      updateLocation(latitude, longitude, 18);
+    });
+  }, [clearMarkers, updateLocation]);
+
   return (
     <>
       <div className="relative">
@@ -65,10 +77,10 @@ export const MapView = () => {
             onChange={onChange}
           />
         </div>
-        <NaverMap />
+        <NaverMap initialCenter={initialCenter} initialZoom={zoomLevel} isCurrent={isCurrent} />
         <div className="absolute bottom-10 right-4 flex flex-col gap-2 justify-center items-center">
           <SideMenu.Group>
-            <SideMenu position="right" variant="gps" onClick={() => {}} />
+            <SideMenu position="right" variant="gps" onClick={() => handleCurrentLocation()} />
             <SideMenu position="right" variant="link" onClick={() => navigate('/link')} />
             <SideMenu position="right" variant="emptyBookMark" onClick={() => {}} />
           </SideMenu.Group>

--- a/src/utils/CurrentMarker.ts
+++ b/src/utils/CurrentMarker.ts
@@ -1,0 +1,23 @@
+export const CurrentMarker = () => {
+  return `
+    <div style="position: relative; display: flex; justify-content: center; align-items: center;">
+      <div style="
+        width: 20px;
+        height: 20px;
+        background-color: red;
+        border-radius: 50%;
+        border: 2.5px solid white;
+        box-shadow: 0px 0px 5px rgba(0,0,0,0.3);
+        z-index: 1;
+      "></div>
+      <div style="
+        position: absolute;
+        width: 35px;
+        height: 35px;
+        background-color: rgba(255, 0, 0, 0.5);
+        border-radius: 50%;
+        animation: ping 1.5s 2 forwards;
+      "></div>
+    </div>
+  `;
+};

--- a/src/utils/naver/addMarkerToMap.ts
+++ b/src/utils/naver/addMarkerToMap.ts
@@ -4,7 +4,7 @@ import { CustomMarker } from '../CustomMarker';
 
 const MIN_ZOOM = 14;
 
-export const addMarkersToMap = (
+export const addMarkerToMap = (
   mapInstance: React.MutableRefObject<naver.maps.Map | null>,
   markers: Place[],
   markersRef: React.MutableRefObject<naver.maps.Marker[]>,

--- a/src/utils/naver/currentMakersToMap.ts
+++ b/src/utils/naver/currentMakersToMap.ts
@@ -1,0 +1,25 @@
+import { CurrentMarker } from '../CurrentMarker';
+
+export const currentMarkersToMap = (
+  position: { lat: number; lng: number },
+  mapInstance: naver.maps.Map,
+  currentLocationMarkerRef: React.MutableRefObject<naver.maps.Marker | null>
+) => {
+  if (currentLocationMarkerRef.current) {
+    currentLocationMarkerRef.current.setMap(null);
+    currentLocationMarkerRef.current = null;
+  }
+
+  const currentMarker = new naver.maps.Marker({
+    position: new naver.maps.LatLng(position.lat, position.lng),
+    map: mapInstance,
+    icon: {
+      content: CurrentMarker(),
+      anchor: new naver.maps.Point(10, 10),
+    },
+  });
+
+  currentLocationMarkerRef.current = currentMarker;
+  mapInstance.setCenter(new naver.maps.LatLng(position.lat, position.lng));
+  mapInstance.setZoom(18);
+};

--- a/src/utils/naver/currentMarkerToMap.ts
+++ b/src/utils/naver/currentMarkerToMap.ts
@@ -1,6 +1,6 @@
 import { CurrentMarker } from '../CurrentMarker';
 
-export const currentMarkersToMap = (
+export const currentMarkerToMap = (
   position: { lat: number; lng: number },
   mapInstance: naver.maps.Map,
   currentLocationMarkerRef: React.MutableRefObject<naver.maps.Marker | null>


### PR DESCRIPTION
<!-- PR 제목입니다. -->

## 관련 이슈

close #46 

## 📑 작업 내용

- SideMenu 클릭시 현재 위치로 이동하는 기능 구현했습니다.
- `navigator.geolocation` 객체가 현재 위치를 찾기까지 약 3~5초 정도 시간이 걸립니다. 추후 `Loading` 시간 동안 보여줄 컴포넌트 구현이 필요할 것 같습니다!
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 💬 리뷰 중점 사항/기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 사용자의 현재 위치를 중심으로 지도를 표시할 수 있는 `isCurrent` 속성이 `NaverMap` 컴포넌트에 추가되었습니다.
	- 새로운 커스텀 훅 `useMapState`가 도입되어 지도 상태 관리를 개선했습니다.
	- 현재 위치를 표시하는 `CurrentMarker` 컴포넌트가 추가되었습니다.
	- `ping` 애니메이션 CSS 키프레임이 추가되어 스타일링 향상되었습니다.

- **버그 수정**
	- 마커 관리 및 지도 초기화 로직이 개선되었습니다. 

- **문서화**
	- 관련 문서 및 주석이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->