### PR TITLE
[FIX] BottomSheet 컴포넌트와 버튼 연결 문제

### DIFF
--- a/src/components/common/BottomSheet/BottomSheet.stories.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.stories.tsx
@@ -25,13 +25,11 @@ export const Basic: Story = {
         <Button variant="primary" size="medium" onClick={handleClickBottomSheet}>
           Open BottomSheet
         </Button>
-        {isOpen && (
-          <BottomSheet isOpen={isOpen}>
-            <div className="flex flex-col gap-6 items-center">
-              <div>Contents ...</div>
-            </div>
-          </BottomSheet>
-        )}
+        <BottomSheet isOpen={isOpen} setIsOpen={setIsOpen}>
+          <div className="flex flex-col gap-6 items-center">
+            <div>Contents ...</div>
+          </div>
+        </BottomSheet>
       </>
     );
   },

--- a/src/components/common/BottomSheet/BottomSheet.types.ts
+++ b/src/components/common/BottomSheet/BottomSheet.types.ts
@@ -10,6 +10,10 @@ export type Props = ComponentPropsWithoutRef<'div'> & {
    * The content to be displayed inside the BottomSheet.
    */
   children: ReactNode;
+  /**
+   * Function to set the state of BottomSheet.
+   */
+  setIsOpen: (value: boolean) => void;
 };
 
 export type DragInfo = {

--- a/src/components/common/BottomSheet/index.tsx
+++ b/src/components/common/BottomSheet/index.tsx
@@ -9,39 +9,31 @@ import { BottomSheetHeader } from './BottomSheetHeader';
 
 import { Portal } from '../Portal';
 
-export const BottomSheet = memo(
-  ({ children, isOpen, setIsOpen }: Props & { setIsOpen: (value: boolean) => void }) => {
-    const dragControls = useDragControls();
+export const BottomSheet = memo(({ children, isOpen, setIsOpen }: Props) => {
+  const dragControls = useDragControls();
 
-    const {
-      sheetHeight,
-      //isHidden,
-      isInteractionDisabled,
-      handleDrag,
-      handleDragEnd,
-      bottomSheetRef,
-    } = useBottomSheet(isOpen, setIsOpen);
+  const { sheetHeight, isInteractionDisabled, handleDrag, handleDragEnd, bottomSheetRef } =
+    useBottomSheet(isOpen, setIsOpen);
 
-    return (
-      <Portal isOpen={isOpen}>
-        <motion.div
-          ref={bottomSheetRef}
-          className="absolute bottom-0 left-0 w-full bg-white shadow-[0px_-4px_10px_0px_rgba(0,0,0,0.1)] rounded-t-3xl p-4 overflow-hidden z-40 h-${sheetHeight}"
-          drag="y"
-          dragControls={dragControls}
-          dragElastic={0}
-          dragConstraints={{ top: 0, bottom: 0 }}
-          onDrag={handleDrag}
-          onDragEnd={handleDragEnd}
-          animate={BOTTOM_SHEET_ANIMATION.animate(sheetHeight, !isOpen)}
-          transition={BOTTOM_SHEET_ANIMATION.transition}
-          onPointerDown={(e) => !isInteractionDisabled && dragControls.start(e)}
-          exit={BOTTOM_SHEET_ANIMATION.exit}
-        >
-          <BottomSheetHeader />
-          {children}
-        </motion.div>
-      </Portal>
-    );
-  }
-);
+  return (
+    <Portal isOpen={isOpen}>
+      <motion.div
+        ref={bottomSheetRef}
+        className="absolute bottom-0 left-0 w-full bg-white shadow-[0px_-4px_10px_0px_rgba(0,0,0,0.1)] rounded-t-3xl p-4 overflow-hidden z-40 h-${sheetHeight}"
+        drag="y"
+        dragControls={dragControls}
+        dragElastic={0}
+        dragConstraints={{ top: 0, bottom: 0 }}
+        onDrag={handleDrag}
+        onDragEnd={handleDragEnd}
+        animate={BOTTOM_SHEET_ANIMATION.animate(sheetHeight, !isOpen)}
+        transition={BOTTOM_SHEET_ANIMATION.transition}
+        onPointerDown={(e) => !isInteractionDisabled && dragControls.start(e)}
+        exit={BOTTOM_SHEET_ANIMATION.exit}
+      >
+        <BottomSheetHeader />
+        {children}
+      </motion.div>
+    </Portal>
+  );
+});

--- a/src/components/common/BottomSheet/index.tsx
+++ b/src/components/common/BottomSheet/index.tsx
@@ -9,31 +9,31 @@ import { BottomSheetHeader } from './BottomSheetHeader';
 
 import { Portal } from '../Portal';
 
-export const BottomSheet = memo(({ children, isOpen }: Props) => {
-  const dragControls = useDragControls();
+export const BottomSheet = memo(
+  ({ children, isOpen, setIsOpen }: Props & { setIsOpen: (value: boolean) => void }) => {
+    const dragControls = useDragControls();
 
-  const {
-    sheetHeight,
-    isHidden,
-    isInteractionDisabled,
-    handleDrag,
-    handleDragEnd,
-    bottomSheetRef,
-  } = useBottomSheet(isOpen);
+    const {
+      sheetHeight,
+      //isHidden,
+      isInteractionDisabled,
+      handleDrag,
+      handleDragEnd,
+      bottomSheetRef,
+    } = useBottomSheet(isOpen, setIsOpen);
 
-  return (
-    <Portal isOpen={!isHidden}>
-      {!isHidden && (
+    return (
+      <Portal isOpen={isOpen}>
         <motion.div
           ref={bottomSheetRef}
-          className="absolute bottom-0 left-0 w-full bg-white shadow-[0px_-4px_10px_0px_rgba(0,0,0,0.1)] rounded-t-3xl p-4 overflow-hidden z-[1000] h-${sheetHeight}"
+          className="absolute bottom-0 left-0 w-full bg-white shadow-[0px_-4px_10px_0px_rgba(0,0,0,0.1)] rounded-t-3xl p-4 overflow-hidden z-40 h-${sheetHeight}"
           drag="y"
           dragControls={dragControls}
           dragElastic={0}
           dragConstraints={{ top: 0, bottom: 0 }}
           onDrag={handleDrag}
           onDragEnd={handleDragEnd}
-          animate={BOTTOM_SHEET_ANIMATION.animate(sheetHeight, isHidden)}
+          animate={BOTTOM_SHEET_ANIMATION.animate(sheetHeight, !isOpen)}
           transition={BOTTOM_SHEET_ANIMATION.transition}
           onPointerDown={(e) => !isInteractionDisabled && dragControls.start(e)}
           exit={BOTTOM_SHEET_ANIMATION.exit}
@@ -41,7 +41,7 @@ export const BottomSheet = memo(({ children, isOpen }: Props) => {
           <BottomSheetHeader />
           {children}
         </motion.div>
-      )}
-    </Portal>
-  );
-});
+      </Portal>
+    );
+  }
+);

--- a/src/hooks/common/useBottomSheet.tsx
+++ b/src/hooks/common/useBottomSheet.tsx
@@ -3,9 +3,8 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { DragInfo } from '@/components/common/BottomSheet/BottomSheet.types';
 import { INITIAL_HEIGHT, MIN_VISIBLE_HEIGHT, MAX_HEIGHT } from '@/constants/bottomSheetOptions';
 
-export const useBottomSheet = (isOpen: boolean) => {
+export const useBottomSheet = (isOpen: boolean, setIsOpen: (value: boolean) => void) => {
   const [sheetHeight, setSheetHeight] = useState(INITIAL_HEIGHT);
-  const [isHidden, setIsHidden] = useState(false);
   const [isInteractionDisabled, setIsInteractionDisabled] = useState(false);
   const dragOffsetRef = useRef(0);
   const initialPositionRef = useRef(INITIAL_HEIGHT);
@@ -14,12 +13,12 @@ export const useBottomSheet = (isOpen: boolean) => {
   useEffect(() => {
     if (isOpen) {
       setSheetHeight(INITIAL_HEIGHT);
-      setIsHidden(false);
+      setIsOpen(true);
       setIsInteractionDisabled(false);
       dragOffsetRef.current = 0;
       initialPositionRef.current = INITIAL_HEIGHT;
     }
-  }, [isOpen]);
+  }, [isOpen, setIsOpen]);
 
   useEffect(() => {
     const handleClickOutside = (event: Event) => {
@@ -59,7 +58,7 @@ export const useBottomSheet = (isOpen: boolean) => {
 
   const handleDragEnd = useCallback(() => {
     if (sheetHeight <= MIN_VISIBLE_HEIGHT) {
-      setIsHidden(true);
+      setIsOpen(false);
       setIsInteractionDisabled(true);
       return;
     }
@@ -68,11 +67,10 @@ export const useBottomSheet = (isOpen: boolean) => {
       setSheetHeight(MAX_HEIGHT);
       return;
     }
-  }, [sheetHeight]);
+  }, [setIsOpen, sheetHeight]);
 
   return {
     sheetHeight,
-    isHidden,
     isInteractionDisabled,
     handleDrag,
     handleDragEnd,


### PR DESCRIPTION
## 관련 이슈

close #54

## 📑 작업 내용

- 부모 객체에서 setIsOpen을 바텀시트로 전달하도록 수정하여 버튼과 바텀시트 상태를 일치시켰습니다.
- z-index 값을 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- `BottomSheet` 컴포넌트의 상태 관리를 외부에서 제어할 수 있도록 `setIsOpen` 프로퍼티 추가.
	- `BottomSheet`의 렌더링 로직 간소화 및 항상 렌더링되도록 변경.

- **버그 수정**
	- 내부 상태 관리 개선으로 `isHidden` 변수 제거.

- **문서화**
	- `BottomSheet` 및 `useBottomSheet` 훅의 메서드 시그니처 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->