### PR TITLE
[FEAT] cursor 방식 페이지네이션 구현

### DIFF
--- a/src/components/common/Button/Button.variants.ts
+++ b/src/components/common/Button/Button.variants.ts
@@ -10,8 +10,8 @@ export const ButtonVariants = cva(
         gray: 'bg-gray-150 text-gray-950 hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed',
       },
       size: {
-        large: 'w-full h-16 text-xl font-medium',
-        medium: 'w-[19rem] h-14 text-lg font-medium',
+        large: 'w-full h-14 text-xl font-medium',
+        medium: 'w-[19rem] h-12 text-lg font-medium',
       },
     },
     defaultVariants: {

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -13,7 +13,7 @@ const Content = ({ children }: PropsWithChildren) => {
       initial={FADE_IN_ANIMATION.initial}
       animate={FADE_IN_ANIMATION.animate}
       exit={FADE_IN_ANIMATION.exit}
-      className="relative z-modal bg-white px-6 py-7 rounded-[1.25rem] shadow-lg"
+      className="relative z-modal bg-white px-4 py-4 rounded-[1.25rem] shadow-lg"
     >
       {children}
     </motion.div>

--- a/src/components/features/BookmarkDetail/BookmarkDetail.tsx
+++ b/src/components/features/BookmarkDetail/BookmarkDetail.tsx
@@ -135,9 +135,9 @@ export const BookmarkDetail = ({ bookmarkId, onPrev }: Props) => {
               )}
             </div>
             {index < allMarkers.length - 1 && <hr className="border-dashed pt-2" />}
-            <div ref={observerTarget} />
           </div>
         ))}
+        <div ref={observerTarget} />
       </ListCard>
       <div className="flex gap-4 mt-5">
         {isEditing ? (

--- a/src/components/features/BookmarkDetail/BookmarkDetail.tsx
+++ b/src/components/features/BookmarkDetail/BookmarkDetail.tsx
@@ -6,13 +6,12 @@ import { Chip } from '@/components/common/Chip';
 import { Icon } from '@/components/common/Icon';
 import { ListCard } from '@/components/common/ListCard';
 import { Body1, Body2, Body4 } from '@/components/common/Typography';
+import { Delete } from '@/components/features/DeleteModal';
 import { markersAtom } from '@/contexts/MarkerAtom';
 import { useDeleteMarkers } from '@/hooks/api/marker/useDeleteMarkers';
 import { useMarkerList } from '@/hooks/api/marker/useMarkerList';
 import { useAuth } from '@/hooks/auth/useAuth';
 import { Category } from '@/types/naver';
-
-import { Delete } from '../DeleteModal';
 
 type Props = { bookmarkId: number; onPrev: () => void };
 export const BookmarkDetail = ({ bookmarkId, onPrev }: Props) => {
@@ -57,10 +56,8 @@ export const BookmarkDetail = ({ bookmarkId, onPrev }: Props) => {
   }, [allMarkers, setMarkers]);
 
   const selectedMarkerName = useMemo(
-    () =>
-      data?.pages.flatMap((page) => page.markers.data).find((item) => item.markerId === selectedId)
-        ?.title || '마커',
-    [data?.pages, selectedId]
+    () => allMarkers.find((item) => item.markerId === selectedId)?.title || '마커',
+    [allMarkers, selectedId]
   );
 
   const handleObserver = useCallback(

--- a/src/components/features/BookmarkDetail/BookmarkDetail.tsx
+++ b/src/components/features/BookmarkDetail/BookmarkDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAtom } from 'jotai';
 
 import { Button } from '@/components/common/Button';
@@ -19,11 +19,12 @@ export const BookmarkDetail = ({ bookmarkId, onPrev }: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [selectedId, setSelectedId] = useState<number>(0);
+  const [, setMarkers] = useAtom(markersAtom);
+  const observerTarget = useRef<HTMLDivElement>(null);
 
   const { token } = useAuth();
-  const { data } = useMarkerList(bookmarkId, token);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useMarkerList(bookmarkId, token);
   const deleteMarkersMutation = useDeleteMarkers();
-  const [, setMarkers] = useAtom(markersAtom);
 
   const handleToggleSelect = (markerId: number) => {
     setSelectedId((prev) => (prev === markerId ? 0 : markerId));
@@ -40,14 +41,51 @@ export const BookmarkDetail = ({ bookmarkId, onPrev }: Props) => {
     setSelectedId(0);
   };
 
-  useEffect(() => {
-    if (data?.markers?.data) {
-      setMarkers(data.markers.data);
-    }
-  }, [data?.markers?.data, setMarkers]);
+  const allMarkers = useMemo(
+    () => (data?.pages ? data.pages.flatMap((page) => page.markers.data) : []),
+    [data?.pages]
+  );
 
-  const selectedMarkerName =
-    data?.markers.data.find((item) => item.markerId === selectedId)?.title || '마커';
+  useEffect(() => {
+    if (allMarkers.length) {
+      setMarkers((prevMarkers) => {
+        const newMarkersStr = JSON.stringify(allMarkers);
+        const prevMarkersStr = JSON.stringify(prevMarkers);
+        return newMarkersStr !== prevMarkersStr ? allMarkers : prevMarkers;
+      });
+    }
+  }, [allMarkers, setMarkers]);
+
+  const selectedMarkerName = useMemo(
+    () =>
+      data?.pages.flatMap((page) => page.markers.data).find((item) => item.markerId === selectedId)
+        ?.title || '마커',
+    [data?.pages, selectedId]
+  );
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      });
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleObserver, {
+      root: null,
+      rootMargin: '20px',
+      threshold: 0.1,
+    });
+
+    if (observerTarget.current) {
+      observer.observe(observerTarget.current);
+    }
+    return () => observer.disconnect();
+  }, [handleObserver]);
 
   return (
     <div>
@@ -62,15 +100,15 @@ export const BookmarkDetail = ({ bookmarkId, onPrev }: Props) => {
           className="cursor-pointer"
         />
         <Body1 className="my-4 mx-3" weight="semibold" onClick={onPrev}>
-          <span className="text-primary mr-2">{data?.bookmarkName}</span>
+          <span className="text-primary mr-2">{data?.pages[0]?.bookmarkName}</span>
           리스트
         </Body1>
       </div>
       <ListCard>
-        {data?.markers.data.map((item, index) => (
+        {allMarkers.map((item, index) => (
           <div key={item.markerId}>
             <div
-              className={`flex flex-row justify-between gap-4 items-center ${index !== data.markers.data.length - 1 && 'pb-2'}`}
+              className={`flex flex-row justify-between gap-4 items-center ${index !== allMarkers.length - 1 && 'pb-2'} `}
             >
               <div className="flex flex-col gap-1 py-2">
                 <div className="flex flex-row gap-3 items-center">
@@ -96,8 +134,8 @@ export const BookmarkDetail = ({ bookmarkId, onPrev }: Props) => {
                 />
               )}
             </div>
-
-            {index < data.markers.data.length - 1 && <hr className="border-dashed pt-2" />}
+            {index < allMarkers.length - 1 && <hr className="border-dashed pt-2" />}
+            <div ref={observerTarget} />
           </div>
         ))}
       </ListCard>

--- a/src/components/features/BookmarkList/BookmarkList.tsx
+++ b/src/components/features/BookmarkList/BookmarkList.tsx
@@ -113,7 +113,6 @@ export const BookmarkList = ({ onNext }: Props) => {
           .map((item, index) => (
             <div key={item.bookmarkId}>
               <div
-                ref={observerTarget}
                 onClick={() => handleBookmarkClick(item.bookmarkId)}
                 className="flex flex-row justify-between items-center cursor-pointer"
               >
@@ -151,6 +150,7 @@ export const BookmarkList = ({ onNext }: Props) => {
               )}
             </div>
           ))}
+        <div ref={observerTarget} />
       </ListCard>
       <div className="flex gap-4 mt-5">
         {isEditing ? (

--- a/src/components/features/BookmarkList/BookmarkList.tsx
+++ b/src/components/features/BookmarkList/BookmarkList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/common/Button';
 import { Icon } from '@/components/common/Icon';
@@ -22,9 +22,11 @@ export const BookmarkList = ({ onNext }: Props) => {
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [selectedId, setSelectedId] = useState<number>(0);
   const [bookmarkName, setBookmarkName] = useState<string>('');
+  const observerTarget = useRef<HTMLDivElement>(null);
 
   const { token } = useAuth();
-  const { data } = useBookMarkList(token);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useBookMarkList(token);
+
   const deleteBookmarkMutation = useDeleteBookmark();
   const newBookmarkMutation = useNewBookMark(token);
 
@@ -63,7 +65,32 @@ export const BookmarkList = ({ onNext }: Props) => {
   };
 
   const selectedItemName =
-    data?.data.find((item) => item.bookmarkId === selectedId)?.name || '북마크';
+    data?.pages.flatMap((page) => page.data).find((item) => item.bookmarkId === selectedId)?.name ||
+    '북마크';
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      });
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleObserver, {
+      root: null,
+      rootMargin: '20px',
+      threshold: 0.1,
+    });
+
+    if (observerTarget.current) {
+      observer.observe(observerTarget.current);
+    }
+    return () => observer.disconnect();
+  }, [handleObserver]);
 
   return (
     <>
@@ -81,44 +108,49 @@ export const BookmarkList = ({ onNext }: Props) => {
           </Body2>
         </div>
         <hr className="border-dashed pt-2" />
-        {data?.data.map((item, index) => (
-          <div key={item.bookmarkId}>
-            <div
-              onClick={() => handleBookmarkClick(item.bookmarkId)}
-              className="flex flex-row justify-between items-center cursor-pointer"
-            >
-              <div className="flex flex-row gap-4 py-2.5 items-center justify-center">
-                {item.youtuberProfile ? (
-                  <img
-                    src={item.youtuberProfile}
-                    className="w-12 h-12 rounded-full"
-                    alt={`${item.name}의 프로필 이미지`}
-                  />
-                ) : (
-                  <Icon
-                    name={findyIconNames[index % findyIconNames.length]}
-                    className="w-11 h-11"
-                  />
-                )}
-                <div className="flex flex-col py-1">
-                  <Body2 weight="medium">{item.name}</Body2>
-                  <div className="flex flex-row items-center gap-1">
-                    <Icon name="location" size={15} />
-                    <Body3 className=" text-gray-500">{item.markersCount}</Body3>
+        {data?.pages
+          .flatMap((page) => page.data)
+          .map((item, index) => (
+            <div key={item.bookmarkId}>
+              <div
+                ref={observerTarget}
+                onClick={() => handleBookmarkClick(item.bookmarkId)}
+                className="flex flex-row justify-between items-center cursor-pointer"
+              >
+                <div className="flex flex-row gap-4 py-2.5 items-center justify-center">
+                  {item.youtuberProfile ? (
+                    <img
+                      src={item.youtuberProfile}
+                      className="w-12 h-12 rounded-full"
+                      alt={`${item.name}의 프로필 이미지`}
+                    />
+                  ) : (
+                    <Icon
+                      name={findyIconNames[index % findyIconNames.length]}
+                      className="w-11 h-11"
+                    />
+                  )}
+                  <div className="flex flex-col py-1">
+                    <Body2 weight="medium">{item.name}</Body2>
+                    <div className="flex flex-row items-center gap-1">
+                      <Icon name="location" size={15} />
+                      <Body3 className=" text-gray-500">{item.markersCount}</Body3>
+                    </div>
                   </div>
                 </div>
+                {isEditing && (
+                  <Icon
+                    name="check"
+                    className="cursor-pointer h-7 w-7 flex-shrink-0"
+                    color={selectedId === item.bookmarkId ? 'primary' : 'gray'}
+                  />
+                )}
               </div>
-              {isEditing && (
-                <Icon
-                  name="check"
-                  className="cursor-pointer h-7 w-7 flex-shrink-0"
-                  color={selectedId === item.bookmarkId ? 'primary' : 'gray'}
-                />
+              {index < data.pages.flatMap((page) => page.data).length - 1 && (
+                <hr className="border-dashed pt-2" />
               )}
             </div>
-            {index < data.data.length - 1 && <hr className="border-dashed pt-2" />}
-          </div>
-        ))}
+          ))}
       </ListCard>
       <div className="flex gap-4 mt-5">
         {isEditing ? (

--- a/src/components/features/SearchResultsList/BookmarkSelectionList.tsx
+++ b/src/components/features/SearchResultsList/BookmarkSelectionList.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/common/Button';
 import { Icon } from '@/components/common/Icon';
 import { ListCard } from '@/components/common/ListCard';
 import { Body1, Body2, Body3 } from '@/components/common/Typography';
+import { findyIconNames } from '@/constants/findyIcons';
 import { useBookMarkList } from '@/hooks/api/bookmarks/useBookMarkList';
 import { NewMarker, useNewMarker } from '@/hooks/api/marker/useNewMarker';
 import { useAuth } from '@/hooks/auth/useAuth';
@@ -16,10 +17,11 @@ type Props = {
 
 export const BookmarkSelectionList = ({ selectedPlace, onNext }: Props) => {
   const { token } = useAuth();
-  const { data } = useBookMarkList(token);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useBookMarkList(token);
   const { clearMarkers } = useMarkers();
   const [bookmarkId, setBookmarkId] = useState<number>(0);
   const mutation = useNewMarker(bookmarkId, token);
+  const observerTarget = useRef<HTMLDivElement>(null);
 
   const handleToggleSelect = (id: number) => {
     setBookmarkId((prev) => (prev === id ? 0 : id));
@@ -37,43 +39,77 @@ export const BookmarkSelectionList = ({ selectedPlace, onNext }: Props) => {
     }
   };
 
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      });
+    },
+    [fetchNextPage, hasNextPage, isFetchingNextPage]
+  );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleObserver, {
+      root: null,
+      rootMargin: '100px',
+      threshold: 0.1,
+    });
+
+    if (observerTarget.current) {
+      observer.observe(observerTarget.current);
+    }
+    return () => observer.disconnect();
+  }, [handleObserver]);
+
   return (
     <div className="flex flex-col gap-4 ">
       <Body1 className="my-3 mx-3">북마크 리스트</Body1>
       <ListCard>
-        {data?.data.map((item, index) => (
-          <div key={item.bookmarkId}>
-            <div className={`flex flex-row justify-between items-center `}>
-              <div className="flex flex-row gap-4 py-2.5 items-center justify-center">
-                {item.youtuberProfile ? (
-                  <img
-                    src={item.youtuberProfile}
-                    className="w-12 h-12 rounded-full"
-                    alt={`${item.name}의 프로필 이미지`}
-                  />
-                ) : (
-                  <Icon name="findy1" className="w-11 h-11" />
-                )}
-                <div className="flex flex-col py-1">
-                  <Body2 weight="medium">{item.name}</Body2>
-                  <div className="flex flex-row items-center gap-1">
-                    <Icon name="location" size={15} />
-                    <Body3 className=" text-gray-500">{item.markersCount}</Body3>
+        {data?.pages
+          .flatMap((page) => page.data)
+          .map((item, index) => (
+            <div key={item.bookmarkId}>
+              <div
+                className="flex flex-row justify-between items-center cursor-pointer"
+                onClick={() => handleToggleSelect(item.bookmarkId)}
+              >
+                <div className="flex flex-row gap-4 py-2.5 items-center justify-center">
+                  {item.youtuberProfile ? (
+                    <img
+                      src={item.youtuberProfile}
+                      className="w-12 h-12 rounded-full"
+                      alt={`${item.name}의 프로필 이미지`}
+                    />
+                  ) : (
+                    <Icon
+                      name={findyIconNames[index % findyIconNames.length]}
+                      className="w-11 h-11"
+                    />
+                  )}
+                  <div className="flex flex-col py-1">
+                    <Body2 weight="medium">{item.name}</Body2>
+                    <div className="flex flex-row items-center gap-1">
+                      <Icon name="location" size={15} />
+                      <Body3 className=" text-gray-500">{item.markersCount}</Body3>
+                    </div>
                   </div>
                 </div>
+                {item.bookmarkType !== 'YOUTUBE' && (
+                  <Icon
+                    name="check"
+                    className="cursor-pointer h-7"
+                    color={bookmarkId === item.bookmarkId ? 'primary' : 'gray'}
+                  />
+                )}
               </div>
-              {item.bookmarkType !== 'YOUTUBE' && (
-                <Icon
-                  name="check"
-                  className="cursor-pointer h-7"
-                  color={bookmarkId === item.bookmarkId ? 'primary' : 'gray'}
-                  onClick={() => handleToggleSelect(item.bookmarkId)}
-                />
+              {index < data.pages.flatMap((page) => page.data).length - 1 && (
+                <hr className="border-dashed pt-2" />
               )}
+              <div ref={observerTarget} className="h-1" />
             </div>
-            {index < data.data.length - 1 && <hr className="border-dashed pt-2" />}
-          </div>
-        ))}
+          ))}
       </ListCard>
       <Button variant="primary" size="large" onClick={handleSave} disabled={bookmarkId === 0}>
         저장하기

--- a/src/components/features/SearchResultsList/BookmarkSelectionList.tsx
+++ b/src/components/features/SearchResultsList/BookmarkSelectionList.tsx
@@ -53,7 +53,7 @@ export const BookmarkSelectionList = ({ selectedPlace, onNext }: Props) => {
   useEffect(() => {
     const observer = new IntersectionObserver(handleObserver, {
       root: null,
-      rootMargin: '100px',
+      rootMargin: '20px',
       threshold: 0.1,
     });
 

--- a/src/components/features/SearchResultsList/BookmarkSelectionList.tsx
+++ b/src/components/features/SearchResultsList/BookmarkSelectionList.tsx
@@ -107,9 +107,9 @@ export const BookmarkSelectionList = ({ selectedPlace, onNext }: Props) => {
               {index < data.pages.flatMap((page) => page.data).length - 1 && (
                 <hr className="border-dashed pt-2" />
               )}
-              <div ref={observerTarget} className="h-1" />
             </div>
           ))}
+        <div ref={observerTarget} />
       </ListCard>
       <Button variant="primary" size="large" onClick={handleSave} disabled={bookmarkId === 0}>
         저장하기

--- a/src/hooks/api/bookmarks/useBookMarkList.ts
+++ b/src/hooks/api/bookmarks/useBookMarkList.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { get } from '@/lib/axios';
 
@@ -20,13 +20,15 @@ export type BookmarkDetail = {
 };
 
 export const useBookMarkList = (token: string) => {
-  return useQuery<Bookmarks>({
+  return useInfiniteQuery<Bookmarks>({
     queryKey: ['bookmarklist', token],
-    queryFn: () =>
-      get<Bookmarks>('api/bookmarks?cursor=0&size=10', {
+    queryFn: ({ pageParam = 0 }) =>
+      get<Bookmarks>(`api/bookmarks?cursor=${pageParam}&size=7`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
       }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursor : undefined),
   });
 };

--- a/src/hooks/api/marker/useMarkerList.ts
+++ b/src/hooks/api/marker/useMarkerList.ts
@@ -37,8 +37,6 @@ export const useMarkerList = (markerId: number, token: string) => {
         },
       }),
     initialPageParam: 0,
-    getNextPageParam: (page) => {
-      return page.markers.nextCursor || undefined;
-    },
+    getNextPageParam: (page) => (page.markers.hasNext ? page.markers.nextCursor : undefined),
   });
 };

--- a/src/hooks/api/marker/useMarkerList.ts
+++ b/src/hooks/api/marker/useMarkerList.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { get } from '@/lib/axios';
 
@@ -28,13 +28,17 @@ export type MarkerDetail = {
 };
 
 export const useMarkerList = (markerId: number, token: string) => {
-  return useQuery<Marker>({
+  return useInfiniteQuery<Marker>({
     queryKey: ['marker', markerId, token],
-    queryFn: () =>
-      get<Marker>(`api/markers/${markerId}?cursor=0&size=10`, {
+    queryFn: ({ pageParam = 0 }) =>
+      get<Marker>(`api/markers/${markerId}?cursor=${pageParam}&size=7`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
       }),
+    initialPageParam: 0,
+    getNextPageParam: (page) => {
+      return page.markers.nextCursor || undefined;
+    },
   });
 };

--- a/src/utils/CustomMarker.ts
+++ b/src/utils/CustomMarker.ts
@@ -42,7 +42,7 @@ export const CustomMarker = ({
       <object data="${markerIcon}" type="image/svg+xml" style="width: 37px; height: 47px;"></object>
       <object data="${categoryIcon}" type="image/svg+xml" style="width: 33px; height: 33px; position: absolute; left: 50%; top: 45%; transform: translate(-50%, -50%);"></object>
     </button>
-    <span style="display: block; font-size: 11px; font-weight: 600; color: black; text-shadow: 1px 1px 2px white; text-align: center; white-space: normal; margin-top: 5px;">
+    <span style="display: block; font-size: 12px; font-weight: 400; color: black; text-align: center; white-space: normal; margin-top: 4px;">
       ${shouldShowTitle ? title : ''}
     </span>
   </div>


### PR DESCRIPTION
<!-- PR 제목입니다. -->

## 관련 이슈

close #69 

## 📑 작업 내용

- `useInfiniteQuery` 사용하여 cursor 방식 페이지네이션 구현했습니다. `size` 만큼 데이터를 불러오다가, `hasNext` 값이 존재할 경우 `true`일 경우 다음 `pageParms`로 `nextCursor`를 요청하는 방법입니다.
- `IntersectionObserver`는 브라우저 API로, 특정 요소가 부모 요소나 뷰포트에 보이는지 여부를 관찰하는 객체입니다.
- 따라서 스크롤 시 객체가 더이상 존재하지 않을 때 다음 데이터를 불러오도록 구현했습니다.

https://github.com/user-attachments/assets/e0599e14-ada8-42b6-b933-0781c4f58687

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 💬 리뷰 중점 사항/기타 참고 사항

- Marker 조회시, 다음 데이터가 요청될때마다 마커를 보여주는 형식으로 구현했습니다.
<!-- 없다면 적지 않으셔도 됩니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 버튼 컴포넌트의 크기 변형 업데이트: 큰 버튼과 중간 버튼의 높이가 줄어들었습니다.
	- 모달 컴포넌트의 콘텐츠 패딩이 조정되어 레이아웃이 개선되었습니다.
	- 북마크 목록과 선택 목록에서 무한 스크롤 기능이 추가되었습니다.
	- 북마크 및 마커 목록을 위한 페이지네이션 지원이 향상되었습니다.
	- 북마크 세부 정보 컴포넌트의 상태 관리 및 렌더링 성능이 개선되었습니다.

- **버그 수정**
	- 북마크와 마커 데이터의 렌더링 로직이 개선되어 불필요한 업데이트를 방지합니다.

- **스타일**
	- 커스텀 마커의 제목 스타일이 조정되어 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->