### PR TITLE
[FEAT] Loading 컴포넌트, Suspense 추가

### DIFF
--- a/src/components/common/ListCard/index.tsx
+++ b/src/components/common/ListCard/index.tsx
@@ -5,7 +5,7 @@ import { Props } from './ListCard.types';
 export const ListCard = forwardRef<HTMLDivElement, Props>(({ children, ...props }, ref) => {
   return (
     <div
-      className="w-full max-h-[65dvh] h-fit py-5 pl-6 pr-5 rounded-2xl bg-gray-50 overflow-y-scroll"
+      className="w-full max-h-[55dvh] h-fit py-5 pl-6 pr-5 rounded-2xl bg-gray-50 overflow-y-scroll"
       {...props}
       ref={ref}
     >

--- a/src/components/common/Loading/Loading.stories.tsx
+++ b/src/components/common/Loading/Loading.stories.tsx
@@ -1,0 +1,23 @@
+/* eslint-disable no-restricted-exports */
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Loading } from '.';
+
+const meta = {
+  title: 'components/common/Loading',
+  component: Loading,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+type Story = StoryObj<typeof Loading>;
+
+export const Basic: Story = {
+  render: () => {
+    return (
+      <>
+        <Loading className="h-40" />
+      </>
+    );
+  },
+};

--- a/src/components/common/Loading/Loading.types.ts
+++ b/src/components/common/Loading/Loading.types.ts
@@ -1,0 +1,6 @@
+export type Props = {
+  /**
+   * Optional additional class names for customization.
+   */
+  className?: string;
+};

--- a/src/components/common/Loading/index.tsx
+++ b/src/components/common/Loading/index.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/lib/core';
+
+import { Props } from './Loading.types';
+
+export const Loading = ({ className }: Props) => {
+  return (
+    <div
+      className={cn(
+        'w-full max-w-md space-y-3 p-4 flex flex-col items-center justify-start',
+        className
+      )}
+    >
+      <div className="flex items-center gap-4 w-full">
+        <div className="w-16 h-16 rounded-full bg-gray-100 animate-pulse"></div>
+        <div className="flex-1 space-y-2 w-full">
+          <div className="h-4 bg-gray-100 rounded animate-pulse w-2/3"></div>
+          <div className="h-4 bg-gray-100 rounded animate-pulse"></div>
+        </div>
+      </div>
+
+      <div className="w-full bg-gray-100 h-[28rem] animate-pulse rounded-lg"></div>
+    </div>
+  );
+};

--- a/src/components/features/LinkForm/Landing.tsx
+++ b/src/components/features/LinkForm/Landing.tsx
@@ -23,7 +23,7 @@ export const Landing = ({ onNext, onHomeClick }: LinkFormProps) => {
         <Body1>핀디와 함께, 특별한 순간을 찾아보세요</Body1>
       </div>
       <div className="absolute bottom-3 w-full max-w-[30rem] px-4 mb-5">
-        <Button variant="primary" size="large" onClick={() => onNext} className="w-full">
+        <Button variant="primary" size="large" onClick={() => onNext()} className="w-full">
           다음
         </Button>
       </div>

--- a/src/hooks/api/bookmarks/useBookMarkList.ts
+++ b/src/hooks/api/bookmarks/useBookMarkList.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { get } from '@/lib/axios';
 
@@ -12,7 +12,7 @@ export type Bookmarks = {
 
 export type BookmarkDetail = {
   bookmarkId: number;
-  youtuberProfile: string;
+  youtuberProfile?: string;
   name: string;
   markersCount: number;
   bookmarkType: string;
@@ -20,7 +20,7 @@ export type BookmarkDetail = {
 };
 
 export const useBookMarkList = (token: string) => {
-  return useInfiniteQuery<Bookmarks>({
+  return useSuspenseInfiniteQuery<Bookmarks>({
     queryKey: ['bookmarklist', token],
     queryFn: ({ pageParam = 0 }) =>
       get<Bookmarks>(`api/bookmarks?cursor=${pageParam}&size=7`, {

--- a/src/hooks/api/marker/useMarkerList.ts
+++ b/src/hooks/api/marker/useMarkerList.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import { get } from '@/lib/axios';
 
@@ -28,15 +28,17 @@ export type MarkerDetail = {
 };
 
 export const useMarkerList = (markerId: number, token: string) => {
-  return useInfiniteQuery<Marker>({
+  return useSuspenseInfiniteQuery<Marker>({
     queryKey: ['marker', markerId, token],
     queryFn: ({ pageParam = 0 }) =>
-      get<Marker>(`api/markers/${markerId}?cursor=${pageParam}&size=7`, {
+      get<Marker>(`api/markers/${markerId}?cursor=${pageParam}&size=20`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
       }),
     initialPageParam: 0,
-    getNextPageParam: (page) => (page.markers.hasNext ? page.markers.nextCursor : undefined),
+    getNextPageParam: (lastPage) => {
+      return lastPage.markers.hasNext ? lastPage.markers.nextCursor : undefined;
+    },
   });
 };

--- a/src/hooks/common/useBottomFunnel.tsx
+++ b/src/hooks/common/useBottomFunnel.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useState } from 'react';
+import { Suspense, useCallback, useState } from 'react';
 
+import { Loading } from '@/components/common/Loading';
 import { BookmarkDetail } from '@/components/features/BookmarkDetail';
 import { BookmarkList } from '@/components/features/BookmarkList';
 import { ExtractedPlacesList } from '@/components/features/ExtractedPlacesList/ExtractedPlacesList';
@@ -7,11 +8,10 @@ import { SearchResultsList } from '@/components/features/SearchResultsList';
 import { BookmarkSelectionList } from '@/components/features/SearchResultsList/BookmarkSelectionList';
 import { FLOW_CONFIGS, FlowType, STEPS, StepType } from '@/constants/funnelStep';
 import { ExtractResponse } from '@/hooks/api/link/useYoutubePlace';
+import { NewMarker } from '@/hooks/api/marker/useNewMarker';
+import { useAuth } from '@/hooks/auth/useAuth';
 import { useFunnel } from '@/hooks/common/useFunnel';
 import { Place } from '@/types/naver';
-
-import { NewMarker } from '../api/marker/useNewMarker';
-import { useAuth } from '../auth/useAuth';
 
 type bottomFunnelProps = {
   type: FlowType;
@@ -77,7 +77,7 @@ export const useBottomFunnel = ({ type, data }: bottomFunnelProps) => {
     <Funnel>
       {flowConfig.steps.map((stepName) => (
         <Step key={stepName} name={stepName}>
-          {stepComponents[stepName]}
+          <Suspense fallback={<Loading />}>{stepComponents[stepName]}</Suspense>
         </Step>
       ))}
     </Funnel>


### PR DESCRIPTION
<!-- PR 제목입니다. -->

## 관련 이슈

close #75 

## 📑 작업 내용

- Loading 컴포넌트, 스토리북 구현했습니다.
- 기존 tanstack query를 suspense 쿼리로 변경하였습니다. 

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 💬 리뷰 중점 사항/기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->
- 기존의 `useQuery`에서는 데이터를 불러오는 동안 로딩 상태를 관리하기 위해 로딩 상태 변수를 추가하거나 `isLoading` 같은 상태를 수동으로 처리해야 합니다. `useSuspenseQuery`를 사용하면 로딩 상태를 관리하는 코드를 작성할 필요 없이, `Suspense` 컴포넌트와 함께 사용할 수 있습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 새로운 `Loading` 컴포넌트 추가: 사용자에게 로딩 상태를 표시하는 스켈레톤 UI 제공.
	- `ListCard` 컴포넌트의 최대 높이 조정.
  
- **Bug Fixes**
	- `Landing` 컴포넌트에서 버튼 클릭 시 `onNext` 함수가 올바르게 호출되도록 수정.

- **Documentation**
	- `Loading` 컴포넌트에 대한 Storybook 구성 추가.

- **Chores**
	- `useBookMarkList` 및 `useMarkerList` 훅에서 데이터 가져오는 방식을 `useSuspenseInfiniteQuery`로 변경하여 사용자 경험 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->