### PR TITLE
[FIX] 네이버 검색 결과 태그 제거, 카테고리 대분류 추출

### DIFF
--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from 'react';
 import { Props } from './Input.types';
 
 import { Icon } from '../Icon';
-import { Caption } from '../Typography';
+import { Body4, Caption } from '../Typography';
 
 export const Input = forwardRef<HTMLInputElement, Props>(
   ({ value, onClickReset, isValid, errorMessage, ...props }, ref) => {
@@ -29,9 +29,9 @@ export const Input = forwardRef<HTMLInputElement, Props>(
           )}
         </div>
         {helperMessage && (
-          <Caption className="text-primary mt-1">
+          <Body4 className="text-[14px] text-primary mt-1">
             {errorMessage || '유투브 링크 혹은 지도 링크만 가능합니다.'}
-          </Caption>
+          </Body4>
         )}
       </div>
     );

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from 'react';
 import { Props } from './Input.types';
 
 import { Icon } from '../Icon';
-import { Body4, Caption } from '../Typography';
+import { Body4 } from '../Typography';
 
 export const Input = forwardRef<HTMLInputElement, Props>(
   ({ value, onClickReset, isValid, errorMessage, ...props }, ref) => {

--- a/src/components/features/LinkForm/LinkInput.tsx
+++ b/src/components/features/LinkForm/LinkInput.tsx
@@ -25,6 +25,7 @@ export const LinkInput = ({ onNext, onHomeClick, context }: LinkInputProp<string
       <div className="w-full flex flex-col items-start gap-6 my-36 px-6">
         <Body1>{`아래에 링크를 입력해주시면,\n특별한 장소 정보를 추출해드릴게요.`}</Body1>
         <Input
+          autoFocus
           value={inputValue}
           onChange={onChange}
           onBlur={onBlur}

--- a/src/hooks/common/useInput.tsx
+++ b/src/hooks/common/useInput.tsx
@@ -7,7 +7,7 @@ export const useInput = (initialValue = '', validation: string[] = ['https', 'ww
 
   const onChange: ChangeEventHandler<HTMLInputElement> = useCallback((e) => {
     const value = e.target.value;
-    setState(value);
+    setState(value.trim());
   }, []);
 
   const onBlur = useCallback(() => {

--- a/src/pages/MapView.tsx
+++ b/src/pages/MapView.tsx
@@ -16,6 +16,7 @@ import { useMapState } from '@/hooks/common/useMapState';
 import { useMarkers } from '@/hooks/common/useMarkers';
 import { useSessionDataLoader } from '@/hooks/common/useSessionDataLoader';
 import { Place } from '@/types/naver';
+import { parseSearchResult } from '@/utils/parseSearchResult';
 
 export const MapView = () => {
   const { token } = useAuth();
@@ -54,7 +55,7 @@ export const MapView = () => {
     resetCurrentLocation();
     const result = await refetch();
     if (result?.data?.items) {
-      handleDataUpdate(result.data.items, 'search');
+      handleDataUpdate(parseSearchResult(result.data.items), 'search');
     }
   };
 

--- a/src/utils/CustomMarker.ts
+++ b/src/utils/CustomMarker.ts
@@ -42,7 +42,7 @@ export const CustomMarker = ({
       <object data="${markerIcon}" type="image/svg+xml" style="width: 37px; height: 47px;"></object>
       <object data="${categoryIcon}" type="image/svg+xml" style="width: 33px; height: 33px; position: absolute; left: 50%; top: 45%; transform: translate(-50%, -50%);"></object>
     </button>
-    <span style="display: block; font-size: 12px; font-weight: 400; color: black; text-align: center; white-space: normal; margin-top: 4px;">
+    <span style="display: block; font-size: 12px; font-weight: 600; color: black; text-align: center; white-space: normal; margin-top: 4px;">
       ${shouldShowTitle ? title : ''}
     </span>
   </div>

--- a/src/utils/parseSearchResult.ts
+++ b/src/utils/parseSearchResult.ts
@@ -1,0 +1,17 @@
+import { Place } from '@/types/naver';
+
+const removeHtmlTags = (result: string) => {
+  return result.replace(/<\/?[^>]+(>|$)/g, '');
+};
+
+const extractCategory = (category: string) => {
+  return category.split('>')[0];
+};
+
+export const parseSearchResult = (data: Place[]) => {
+  return data.map((item) => ({
+    ...item,
+    title: removeHtmlTags(item.title),
+    category: typeof item.category === 'string' ? extractCategory(item.category) : '',
+  }));
+};


### PR DESCRIPTION
<!-- PR 제목입니다. -->

## 관련 이슈

close #85

## 📑 작업 내용

- 네이버 검색 결과 시 태그가 같이 검색 되는 경우, 태그 제거했습니다.
- 검색 결과시 카테고리 대분류만 보여지도록 수정했습니다. 
- 입력시 띄어쓰기가 존재하는 경우 공백 제거했습니다.

<table>
  <tr>
    <td>as is</td>
    <td>to be</td>
  </tr>
  <tr>
    <td><img width="265" alt="스크린샷 2024-12-04 오후 7 35 05" src="https://github.com/user-attachments/assets/59d28a13-1355-4abe-b4b6-734259f412f4"></td>
    <td><img width="274" alt="스크린샷 2024-12-04 오후 7 54 06" src="https://github.com/user-attachments/assets/fabf4295-ea78-482f-9e91-320bf7787887"></td>
  </tr>
</table>

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 💬 리뷰 중점 사항/기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 입력 처리 로직 개선: 입력값에서 공백이 제거되어 상태 업데이트 시 더 정확한 값이 반영됩니다.
	- 검색 결과 처리 방식 변경: 새로운 유틸리티 함수가 도입되어 검색 결과의 구조가 표준화됩니다.
	- 검색 결과에서 HTML 태그 제거 및 카테고리 추출 기능 추가.
	- 링크 입력 컴포넌트에 자동 포커스 기능 추가: 컴포넌트 렌더링 시 입력 필드가 자동으로 포커스됩니다.

- **스타일**
	- 사용자 정의 마커의 제목 표시 스타일 변경: 제목의 글꼴 두께가 변경되어 시각적 강조가 강화되었습니다.
	- 입력 컴포넌트의 헬퍼 메시지 스타일 변경: 새로운 Body4 컴포넌트로 교체되어 더 나은 시각적 표현을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->